### PR TITLE
Experimental/default parameters to file

### DIFF
--- a/src/main/java/es/upm/etsisi/DefaultParameters.java
+++ b/src/main/java/es/upm/etsisi/DefaultParameters.java
@@ -11,6 +11,7 @@ import java.text.Normalizer;
 public class DefaultParameters {
     private static final int DEFAULT_PLAYERS = 6;
     private static final int DEFAULT_TEAMS = 2;
+    private static final int DEFAULT_PASSWORD_LENGTH = 10;
     private static final String[] DEFAULT_SURNAMES = { "Pérez", "Sánchez", "Jiménez", "Torres", "Blanco", "Navarro",
             "Paredes", "Moreno" };
     private static final String[] DEFAULT_NAMES = { "Luisa", "Manuel", "Kurt", "Sofia", "Robert", "Jose", "Ramón",
@@ -66,6 +67,7 @@ public class DefaultParameters {
         String firstName = DEFAULT_NAMES[randomNumber.nextInt(DEFAULT_NAMES.length)];
         String lastName = DEFAULT_SURNAMES[randomNumber.nextInt(DEFAULT_SURNAMES.length)];
         parameters.add(createUserName(firstName, lastName));
+        parameters.add(createPassword());
         parameters.add(firstName);
         parameters.add(lastName);
 
@@ -85,6 +87,22 @@ public class DefaultParameters {
     private static String createUserName(String firstName, String lastName) {
         String username = String.join(".", normalize(firstName.toLowerCase()), normalize(lastName.toLowerCase()));
         return username.concat("@upm.es");
+    }
+
+    private static String createPassword(){
+        Random randomNumber = new Random();
+        StringBuilder password = new StringBuilder();
+        int key = randomNumber.nextInt(256);
+
+        for (int i = 0; i < DEFAULT_PASSWORD_LENGTH; i++) {
+            char character = (char) (randomNumber.nextInt(26) + 'A');
+            char shuffled = (char) (character ^ key);
+            while (shuffled < 'A' || shuffled > 'Z') {
+                shuffled = (char) ((shuffled ^ key) % ('Z' - 'A' + 1) + 'A');
+            }
+            password.append(shuffled);
+        }
+        return password.toString();
     }
 
     private static String normalize(String string) {

--- a/src/main/java/es/upm/etsisi/views/CLI.java
+++ b/src/main/java/es/upm/etsisi/views/CLI.java
@@ -14,6 +14,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
 
 public class CLI {
     private final Controller controller;
@@ -32,7 +35,13 @@ public class CLI {
         ErrorType error;
         String commandTitle;
 
-        this.addDefaults();
+        String testFile = "sistema-de-gestion-deportiva/src/test/java/es/upm/etsisi/resources/default_output.txt";
+        try {
+            this.addDefaults(testFile);
+        } catch (IOException exception) {
+            exception.toString();
+            exception.printStackTrace();
+        }
 
         do {
             User user = this.controller.getUser();
@@ -87,17 +96,27 @@ public class CLI {
         }
     }
 
-    private void addDefaults() {
+    private void addDefaults(String fileName) throws IOException {
         LinkedList<LinkedList<String>> defaultParameters = DefaultParameters.getDefaultParticipants();
         Iterator<LinkedList<String>> iterator = defaultParameters.iterator();
+        BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
+        writer.write("Parámetros generados aleatoriamente:\n\n");
+
         while (iterator.hasNext()) {
             LinkedList<String> currentParameters = iterator.next();
+
             if (User.isUpmEmail(currentParameters.get(0))) {
                 this.controller.createPlayer(currentParameters.get(0), "default", currentParameters.get(1),
                         currentParameters.get(2), DNI.generateDNI());
+
+                for (String parameter : currentParameters) {
+                    writer.write(parameter + "\t");
+                }
+                writer.newLine();
             } else {
                 this.controller.createTeam(currentParameters.get(0), currentParameters.get(1));
             }
         }
+        writer.close();
     }
 }

--- a/src/main/java/es/upm/etsisi/views/CLI.java
+++ b/src/main/java/es/upm/etsisi/views/CLI.java
@@ -106,8 +106,8 @@ public class CLI {
             LinkedList<String> currentParameters = iterator.next();
 
             if (User.isUpmEmail(currentParameters.get(0))) {
-                this.controller.createPlayer(currentParameters.get(0), "default", currentParameters.get(1),
-                        currentParameters.get(2), DNI.generateDNI());
+                this.controller.createPlayer(currentParameters.get(0), currentParameters.get(1), currentParameters.get(2),
+                        currentParameters.get(3), DNI.generateDNI());
 
                 for (String parameter : currentParameters) {
                     writer.write(parameter + "\t");


### PR DESCRIPTION
## Features
- Passwords are now randomly generated
- Passwords have custom length
- User credentials are now printed to a test output file

## Potential problems
- Necessary IOException handling
- ASCII bit handling (might be ugly)

## Observations
- Password works perfectly, getting different results in each test run.
- Using both BufferedWriter and FileWriter makes the program write the results faster.

### Test Results
![image](https://github.com/user-attachments/assets/f86efa2f-3e51-48dc-b739-fa480400aaec)

### Default Parameters Enhancements:

* Added a new constant `DEFAULT_PASSWORD_LENGTH` and a method `createPassword()` to generate random passwords. These passwords are now included in the generated player parameters. (`src/main/java/es/upm/etsisi/DefaultParameters.java`) [[1]](diffhunk://#diff-7690aff598e5d930d3fe0e402453d5e5000f656b873d3f0978536017b5d7f56cR14) [[2]](diffhunk://#diff-7690aff598e5d930d3fe0e402453d5e5000f656b873d3f0978536017b5d7f56cR70) [[3]](diffhunk://#diff-7690aff598e5d930d3fe0e402453d5e5000f656b873d3f0978536017b5d7f56cR92-R107)

### CLI Updates:

* Imported necessary classes for file handling (`BufferedWriter`, `FileWriter`, `IOException`). (`src/main/java/es/upm/etsisi/views/CLI.java`)
* Modified the `run()` method to call `addDefaults()` with a file name and handle potential `IOException`. (`src/main/java/es/upm/etsisi/views/CLI.java`)
* Updated the `addDefaults()` method to write generated default parameters to a specified file, including handling player passwords. (`src/main/java/es/upm/etsisi/views/CLI.java`)