### PR TITLE
fix: fix #17

### DIFF
--- a/src/main/java/es/upm/etsisi/models/ParticipantList.java
+++ b/src/main/java/es/upm/etsisi/models/ParticipantList.java
@@ -136,11 +136,13 @@ public class ParticipantList extends List<Participant> {
 
         Iterator<Object> iterator = keys.iterator();
         while (iterator.hasNext() && res != null) {
-            Participant participant = this.find(iterator.next());
-            if (participant != null) {
-                res.add(participant);
-            } else {
-                res = null;
+            Object currentItem = iterator.next();
+            Iterator<DNI> dniIterator = ((Collection<DNI>) currentItem).iterator();
+            while (dniIterator.hasNext()){
+                Participant participant = this.find(dniIterator.next());
+                if (participant != null) {
+                    res.add(participant);
+                }
             }
         }
 

--- a/src/main/java/es/upm/etsisi/models/Tournament.java
+++ b/src/main/java/es/upm/etsisi/models/Tournament.java
@@ -123,15 +123,15 @@ public class Tournament {
         ErrorType error;
         LinkedList<Participant> participants = new LinkedList<>(this.participantList.getElements());
 
-        if (participants.size() < 2 || Integer.bitCount(groupSize) != 1 || groupSize >= participants.size()) {
+        if (participants.size() < 2 || groupSize < 2 || Integer.bitCount(groupSize) != 1 || groupSize > participants.size()) {
             return ErrorType.INVALID_MATCH;
         }
-
+        this.matchList.clear();
         Collections.shuffle(participants);
-        for (int i = participants.size() - 1; i < groupSize; i -= groupSize) {
+        for (int i = participants.size() - 1; i >= groupSize - 1; i -= groupSize) {
             LinkedList<Participant> group = new LinkedList<>();
             for (int j = 0; j < groupSize; j++) {
-                group.add(participants.remove(i));
+                group.add(participants.remove(i - j));
             }
             error = this.matchmake(group);
             assert error.isNull();


### PR DESCRIPTION
- Closes #17 
## Changes made
- Fixed for loop logic in ``randomMatchmake()`` in Tournament class
- Added missing groupSize minimun check in ``randomMatchmake()`` in Tournament class
- Fixed List type object not being iterated in ``findAll()`` in ParticipantList class

## Potential issues
Weird cast in ``findAll()`` method, maybe it would be better to redefine the method.

## Observations
- Manual matchmaking is now able to matchmake 2 different players, specified by arguments.
- Random matchmaking seems to be working perfectly, clearing matchList each run and ensuring random matchmaking:
![Captura de pantalla 2024-12-05 194013](https://github.com/user-attachments/assets/80592ed6-d700-4f0d-a2b6-bf8d2659c214)
![Captura de pantalla 2024-12-05 193926](https://github.com/user-attachments/assets/82bf95b8-72b1-434c-a971-22711d4d142d)
